### PR TITLE
adhere to padded-blocks

### DIFF
--- a/hyperemitter.js
+++ b/hyperemitter.js
@@ -204,7 +204,6 @@ function HyperEmitter (db, codecs, opts) {
     that.changes = that.changeStream
     that.status.emit('ready')
   })
-
 }
 
 HyperEmitter.prototype.emit = function (name, data, callback) {


### PR DESCRIPTION
We are in the process of adding back the rule `padded-blocks` into `standard`. It was temporarily disabled because of a bug in eslint which now has been fixed.

This pull request makes sure that your coding style is compliant with the new version.

Please see feross/standard#170 for more info.
